### PR TITLE
Update pull policy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For more information, check out the syntax for Github Actions and relevant docum
 
 - SSH to `dsmlp-login.ucsd.edu`
 
-- RUN `launch-scipy-ml.sh -i <image-fullname> -P Always` . The `-P Always` flag will force the docker host to sync, as it pulls the latest version of the image manifest. Note: a docker image name follows the format `<user>/<image>:<tag>`. The `:<tag>` part will be assumed to be `:latest` if you don't supply it to the launch script. Use tags like `v1` or `test` in the build step to have control over different versions of the same docker image.
+- RUN `export K8S_IMAGE_PULL_POLICY=Always; launch-scipy-ml.sh -i <image-fullname>` . Setting the environment variable `K8S_IMAGE_PULL_POLICY` to `Always` will prompt the docker host to sync, as it pulls the latest version of the image manifest. Note: a docker image name follows the format `<user>/<image>:<tag>`. The `:<tag>` part will be assumed to be `:latest` if you don't supply it to the launch script. Use tags like `v1` or `test` in the build step to have control over different versions of the same docker image.
 
 - Wait for the node to download the image. Download time depends on the image size.
 


### PR DESCRIPTION
Instructions contained reference to outdated -P Always flag - point to K8S_IMAGE_PULL_POLICY=Always instead